### PR TITLE
feat(mod): rename module name to match repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module kubevirt.io/containerized-data-importer-api
+module github.com/kubevirt/containerized-data-importer-api
 
 go 1.17
 


### PR DESCRIPTION
Signed-off-by: Rick Rackow [rick.rackow@gmail.com](mailto:rick.rackow@gmail.com)

This PR changes the modules name to match the repository name. The reason is to get rid of `replace` directives like `kubevirt.io/containerized-data-importer-api => github.com/kubevirt/containerized-data-importer-api` in downstream dependencies.